### PR TITLE
[mlir]Add guard for using posixmemalign <= Android API 28

### DIFF
--- a/mlir/lib/ExecutionEngine/CRunnerUtils.cpp
+++ b/mlir/lib/ExecutionEngine/CRunnerUtils.cpp
@@ -152,7 +152,7 @@ extern "C" void *mlirAlloc(uint64_t size) { return malloc(size); }
 extern "C" void *mlirAlignedAlloc(uint64_t alignment, uint64_t size) {
 #ifdef _WIN32
   return _aligned_malloc(size, alignment);
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) || (defined(__ANDROID_API__) && __ANDROID_API__ <= 28)
   // aligned_alloc was added in MacOS 10.15. Fall back to posix_memalign to also
   // support older versions.
   void *result = nullptr;


### PR DESCRIPTION
aligned_alloc does not exist for Android before 28 too just like apple
#75718